### PR TITLE
feat!: update The constructor has been removed. 

### DIFF
--- a/src/WPOptionBridge.php
+++ b/src/WPOptionBridge.php
@@ -13,12 +13,12 @@ class WPOptionBridge {
     protected $optionGetter;
 
     /**
-     * Constructor
-     * Allows for dependency injection to facilitate testing and flexibility.
+     * Sets the function used to retrieve options. Defaults to WordPress's get_option
+     * if no function is set explicitly.
      *
-     * @param callable $optionGetter Custom function for option retrieval. Defaults to WordPress's get_option.
+     * @param callable $optionGetter Function to retrieve an option.
      */
-    public function __construct(callable $optionGetter = 'get_option') {
+    public function set_option_getter(callable $optionGetter) {
         $this->optionGetter = $optionGetter;
     }
 
@@ -45,11 +45,12 @@ class WPOptionBridge {
      * @return mixed The value of the option, or default if the option does not exist.
      */
     public function get_option($option_name, $default = false) {
+        $getter = $this->optionGetter ?? 'get_option';
         if (!$this->validate_option_name($option_name)) {
             return $default;
         }
 
-        return call_user_func($this->optionGetter, $option_name, $default);
+        return call_user_func($getter, $option_name, $default);
     }
 
     /**


### PR DESCRIPTION
Removed the constructor and instead set the option getter through a method, This approach allows for more flexibility, as the option getter can be set or changed at any point during the lifecycle of the `WPOptionBridge` instance.


### Key Changes:

- **Removed Constructor**: The constructor has been removed, and the `$optionGetter` property is no longer set upon object instantiation.
- **Added `set_option_getter` Method**: This new method allows you to set the callable used for retrieving options. It provides the flexibility to change the option retrieval method dynamically.
- **Default Option Getter**: In the `get_option` method, the `$optionGetter` is used if set; otherwise, it defaults to WordPress's `get_option`. This ensures that the class functions correctly even if `set_option_getter` is never called, providing a sensible default behavior.

### Usage Example:

```php
$optionBridge = new Urisoft\WPOptionBridge();

// Set a custom option getter
$optionBridge->set_option_getter(function($option_name, $default = false) {
    // Custom logic to retrieve option values
});

// Use the class as before
$siteName = $optionBridge->get_option('blogname', 'Default Site Name');
```

This modification makes  `WPOptionBridge` class more flexible and adaptable to different use cases, such as testing or integration with custom option storage mechanisms.