### PR TITLE
fix: provide maximum flexibility

### DIFF
--- a/src/WPOptionBridge.php
+++ b/src/WPOptionBridge.php
@@ -11,15 +11,44 @@ namespace Urisoft;
 class WPOptionBridge {
 
     protected $optionGetter;
+    protected $optionAdder;
+    protected $optionUpdater;
+    protected $optionDeleter;
 
     /**
-     * Sets the function used to retrieve options. Defaults to WordPress's get_option
-     * if no function is set explicitly.
+     * Sets the function used to retrieve options.
      *
      * @param callable $optionGetter Function to retrieve an option.
      */
     public function set_option_getter(callable $optionGetter) {
         $this->optionGetter = $optionGetter;
+    }
+
+    /**
+     * Sets the function used to add options.
+     *
+     * @param callable $optionAdder Function to add an option.
+     */
+    public function set_option_adder(callable $optionAdder) {
+        $this->optionAdder = $optionAdder;
+    }
+
+    /**
+     * Sets the function used to update options.
+     *
+     * @param callable $optionUpdater Function to update an option.
+     */
+    public function set_option_updater(callable $optionUpdater) {
+        $this->optionUpdater = $optionUpdater;
+    }
+
+    /**
+     * Sets the function used to delete options.
+     *
+     * @param callable $optionDeleter Function to delete an option.
+     */
+    public function set_option_deleter(callable $optionDeleter) {
+        $this->optionDeleter = $optionDeleter;
     }
 
     /**
@@ -61,11 +90,12 @@ class WPOptionBridge {
      * @return bool True if option was added, false otherwise.
      */
     public function add_option($option_name, $value) {
+        $adder = $this->optionAdder ?? 'add_option';
         if (!$this->validate_option_name($option_name)) {
             return false;
         }
 
-        return add_option($option_name, $value);
+        return call_user_func($adder, $option_name, $value);
     }
 
     /**
@@ -76,11 +106,12 @@ class WPOptionBridge {
      * @return bool True if option was updated, false otherwise.
      */
     public function update_option($option_name, $value) {
+        $updater = $this->optionUpdater ?? 'update_option';
         if (!$this->validate_option_name($option_name)) {
             return false;
         }
 
-        return update_option($option_name, $value);
+        return call_user_func($updater, $option_name, $value);
     }
 
     /**
@@ -90,10 +121,11 @@ class WPOptionBridge {
      * @return bool True if the option was deleted, false otherwise.
      */
     public function delete_option($option_name) {
+        $deleter = $this->optionDeleter ?? 'delete_option';
         if (!$this->validate_option_name($option_name)) {
             return false;
         }
 
-        return delete_option($option_name);
+        return call_user_func($deleter, $option_name);
     }
 }


### PR DESCRIPTION
To provide maximum flexibility,  we will apply the same approach used for setting the option getter to the other functionalities: adding, updating, and deleting options. This involves creating setter methods for each corresponding WordPress function (`add_option`, `update_option`, `delete_option`) to override or customize. 

### Key Changes:

- **Setter Methods**: Introduced `set_option_adder`, `set_option_updater`, and `set_option_deleter` methods to allow custom functions for adding, updating, and deleting options, respectively.
- **Flexible Function Calls**: Each method (`get_option`, `add_option`, `update_option`, `delete_option`) first checks if a custom function has been set. If not, it defaults to the corresponding WordPress function.
- **Enhanced Customization**: This structure enables full customization of how options are managed, making the class adaptable to a wide range of use cases, including testing and integration with external systems.

### Usage Example:

```php
$optionBridge = new Urisoft\WPOptionBridge();

// Set custom functions
$optionBridge->set_option_getter('my_custom_get_option');
$optionBridge->set_option_adder('my_custom_add_option');
$optionBridge->set_option_updater('my_custom_update_option');
$optionBridge->set_option_deleter('my_custom_delete_option');

// Use the class to manage options
$siteName = $optionBridge->get_option('blogname', 'Default Site Name');
$optionBridge->add_option('my_option', 'value');
$optionBridge->update_option('my_option', 'new value');
$optionBridge->delete_option('my_option');
```